### PR TITLE
Fix error in getting a repo's owner

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -75,7 +75,7 @@ class Project < ActiveRecord::Base
     update_attributes(
     github_id:     repo[:id],
     name:          repo[:name],
-    owner:         repo.fetch(:owner, {})[:login],
+    owner:         repo.to_attrs.fetch(:owner, {})[:login],
     description:   repo[:description],
     homepage:      format_url(repo[:homepage]),
     fork:          repo[:fork],


### PR DESCRIPTION
## TL;DR
Fix an error in getting a project repo's owner. 

Accessing a `Project` instance's `repo` (which calls `Octokit::Client::Repositories#repository`) returns a `[Sawyer::Resource]` object which does not behave like a `Hash` - does not respond to the `fetch` method

This will cause errors during database seeding, when creating a new project (`after_create :update_info` calls `update_from_github`) and when running the `projects:recalculate_scores` Rake task

---

## Long version

When seeding the database, the following is observed:
```
$ bundle exec rake db:seed

Called from $GEM_FOLDER/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
$USER_FOLDER/contribulator/app/models/project.rb:78:in `update_from_github'
$USER_FOLDER/contribulator/app/models/project.rb:51:in `update_info'
...
$USER_FOLDER/contribulator/db/seeds.rb:29:in `<top (required)>'
...
```
This aborts the seeding process and results in projects not created.

### Replicating and diagnosing the error

1. Comment out `app/models/project.rb:8` 
    ```
    # after_create :update_info
    ```
2. Run the following code in a Rails console:
    ```
    > p = Project.create!(
      name: "contribulator", owner: "andrew", homepage: "https://contribulator.herokuapp.com/",
      main_language: "Ruby", github_id: 28201944, fork: false, score: 43.0,
      description: ":+1: Find open source project that are friendly and welcoming"
    )

    > repo = p.github_client.repo 28201944
    ```
3. Run the following commands to diagnose the issue:
    ```
    > repo[:owner]
    => {:login=>"24pullrequests",
    :id=>7920922,
    ...
     
    > repo.fetch(:owner)
    => nil 

    # repo is a Sawyer::Resource object, which does not respond to 'fetch' or other Hash methods
    > repo.class
    => Sawyer::Resource 
    > repo.respond_to? :fetch
     => false
    > repo.respond_to? :dig
     => false
    > repo.respond_to? :to_attrs
     => true

    # Solution: Convert repo into a Hash and fetch its nested attribute
    > repo.to_attrs.fetch(:owner)
    => {:login=>"24pullrequests", :id=>7920922, ...} 
    
    > repo.to_attrs.fetch(:owner, {})[:login]
    => "24pullrequests" 
    ```

4. Verification: Exit Rails console, make code change and uncomment the `after_create` hook. Database seeding should now work correctly and populate 4 projects in the database.

**NOTE**: This does not just affect the database seeding. If unfixed, the following workflow will also fail:

```
$ bundle exec rake projects:import_from_24pr
$ bundle exec rake projects:recalculate_scores

Called from $GEM_FOLDER/activesupport-4.2.8/lib/active_support/dependencies.rb:240:in `load_dependency'
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
$USER_FOLDER/contribulator/app/models/project.rb:78:in `update_from_github'
$USER_FOLDER/contribulator/app/models/project.rb:51:in `update_info'
...
$USER_FOLDER/contribulator/lib/tasks/projects.rake:20:in `block (2 levels) in <top (required)>'
...
```
In addition, creating a new project will also fail, due to `after_create` callback error